### PR TITLE
Fix bringToFront leads to a wrong children index in the scrolling viewpager

### DIFF
--- a/infinitecycleviewpager/src/main/java/com/gigamole/infinitecycleviewpager/InfiniteCycleManager.java
+++ b/infinitecycleviewpager/src/main/java/com/gigamole/infinitecycleviewpager/InfiniteCycleManager.java
@@ -734,8 +734,13 @@ class InfiniteCycleManager implements OnNotifyDataSetChangedListener {
 
             // Bring to front if needed
             if (needBringToFront) {
-                page.bringToFront();
-                mCastViewPageable.invalidate();
+                page.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        page.bringToFront();
+                        mCastViewPageable.invalidate();
+                    }
+                });
             }
 
             if (mOnInfiniteCyclePageTransformListener != null)


### PR DESCRIPTION
When scrolling a ViewPager or redrawing the dirty rectangle of a ViewPager, sometimes one page disappears. It is caused when the page transformer call the bringToFront function, the children view index will be changed. See the viewpager source code.

```java
protected void onPageScrolled(int position, float offset, int offsetPixels) {
        ...
        dispatchOnPageScrolled(position, offset, offsetPixels);

        if (mPageTransformer != null) {
            final int scrollX = getScrollX();
            final int childCount = getChildCount();
            for (int i = 0; i < childCount; i++) {
                final View child = getChildAt(i);
                final LayoutParams lp = (LayoutParams) child.getLayoutParams();

                if (lp.isDecor) continue;
                final float transformPos = (float) (child.getLeft() - scrollX) / getClientWidth();
                mPageTransformer.transformPage(child, transformPos);
            }
        }

        mCalledSuper = true;
    }

```

When the viewpager is scrolling,  `final View child = getChildAt(i);` will be called, and the index may be changed by calling bringToFront function right now.